### PR TITLE
Authentication, AWS subdomains and more gentle identifier escaping

### DIFF
--- a/lib/remote_files/fog_store.rb
+++ b/lib/remote_files/fog_store.rb
@@ -35,6 +35,10 @@ module RemoteFiles
     end
 
     def url(identifier)
+      public_url(identifier)
+    end
+
+    def public_url(identifier)
       case options[:provider]
       when 'AWS'
         path = identifier.split("/").map {|str| Fog::AWS.escape(str) }.join("/")
@@ -49,7 +53,7 @@ module RemoteFiles
 
         "https://storage.cloudfiles.com/#{directory_name}/#{path}"
       else
-        raise "#{self.class.name}#url was not implemented for the #{options[:provider]} provider"
+        raise "#{self.class.name}#public_url was not implemented for the #{options[:provider]} provider"
       end
     end
 

--- a/lib/remote_files/fog_store.rb
+++ b/lib/remote_files/fog_store.rb
@@ -35,9 +35,13 @@ module RemoteFiles
     def url(identifier)
       case options[:provider]
       when 'AWS'
-        "https://s3.amazonaws.com/#{directory_name}/#{Fog::AWS.escape(identifier)}"
+        path = identifier.split("/").map {|str| Fog::AWS.escape(str) }.join("/")
+
+        "https://s3.amazonaws.com/#{directory_name}/#{path}"
       when 'Rackspace'
-        "https://storage.cloudfiles.com/#{directory_name}/#{Fog::Rackspace.escape(identifier, '/')}"
+        path = Fog::Rackspace.escape(identifier, '/')
+
+        "https://storage.cloudfiles.com/#{directory_name}/#{path}"
       else
         raise "#{self.class.name}#url was not implemented for the #{options[:provider]} provider"
       end

--- a/test/fog_store_test.rb
+++ b/test/fog_store_test.rb
@@ -93,11 +93,11 @@ describe RemoteFiles::FogStore do
       before { @store[:provider] = 'AWS' }
 
       it 'should return an S3 url' do
-        @store.url('identifier').must_equal('https://s3.amazonaws.com/directory/identifier')
+        @store.url('identifier').must_equal('https://directory.s3.amazonaws.com/identifier')
       end
 
       it 'should escape illegal characters, but not forward slashes, from the identifier' do
-        @store.url('path.*/to/foo.*').must_equal('https://s3.amazonaws.com/directory/path.%2A/to/foo.%2A')
+        @store.url('path.*/to/foo.*').must_equal('https://directory.s3.amazonaws.com/path.%2A/to/foo.%2A')
       end
     end
 
@@ -127,7 +127,7 @@ describe RemoteFiles::FogStore do
       before { @store[:provider] = 'AWS' }
 
       it 'should create a file if the bucket matches' do
-        file = @store.file_from_url('http://s3-eu-west-1.amazonaws.com/directory/key/on/cloud.txt')
+        file = @store.file_from_url('http://directory.s3-eu-west-1.amazonaws.com/key/on/cloud.txt')
         assert file
         assert_equal 'key/on/cloud.txt', file.identifier
 

--- a/test/fog_store_test.rb
+++ b/test/fog_store_test.rb
@@ -95,6 +95,10 @@ describe RemoteFiles::FogStore do
       it 'should return an S3 url' do
         @store.url('identifier').must_equal('https://s3.amazonaws.com/directory/identifier')
       end
+
+      it 'should escape illegal characters, but not forward slashes, from the identifier' do
+        @store.url('path.*/to/foo.*').must_equal('https://s3.amazonaws.com/directory/path.%2A/to/foo.%2A')
+      end
     end
 
     describe 'for CloudFiles connections' do
@@ -102,6 +106,10 @@ describe RemoteFiles::FogStore do
 
       it 'should return a CloudFiles url' do
         @store.url('identifier').must_equal('https://storage.cloudfiles.com/directory/identifier')
+      end
+
+      it 'should escape illegal characters, but not forward slashes, from the identifier' do
+        @store.url('path.*/to/foo.*').must_equal('https://storage.cloudfiles.com/directory/path.%2A/to/foo.%2A')
       end
     end
 


### PR DESCRIPTION
This PR adds 3 new features, which all touch the same code. Splitting them into 3 pull requests would make them easier to review, but also guarantee merge conflicts :-)
1. The mechanism for escaping file identifiers was too rough on AWS (`Fog::AWS.escape(identifier)`) – if the identifier was a path, and not just a filename, the forward slashes would be escaped, and all files stored in the bucket root path. See https://github.com/bquorning/remote_files/commit/authentication~3.
2. Prefer creating AWS URLs with subdomain, instead of a folder. Code copied almost directly from [CarrierWave](https://github.com/jnicklas/carrierwave/blob/master/lib/carrierwave/storage/fog.rb#L297). See https://github.com/bquorning/remote_files/commit/authentication~2.
3. If a file isn't public, the URL should include an authentication token with a limited TTL. Copied even more almost directly from [CarrierWave](https://github.com/jnicklas/carrierwave/blob/master/lib/carrierwave/storage/fog.rb#L139). See https://github.com/bquorning/remote_files/compare/authentication~2...authentication.

Some tests are missing, and the `authenticated_url_expiration` options isn’t documented or even used properly – it should probably be moved to `configuration.rb`. Let me know what you think.

@staugaard, @morten
