### PR TITLE
Write in binary file mode

### DIFF
--- a/lib/remote_files/file_store.rb
+++ b/lib/remote_files/file_store.rb
@@ -18,7 +18,7 @@ module RemoteFiles
 
       FileUtils.mkdir_p(file_name.parent)
 
-      file_name.open('w') do |f|
+      file_name.open('wb') do |f|
         if file.content.respond_to?(:read)
           while blk = file.content.read(2048)
             f << blk


### PR DESCRIPTION
To avoid getting an `Encoding::UndefinedConversionError`, we change `FileStore#store!` to write in binary mode.
