### PR TITLE
AWS: handle other regions for #url

### DIFF
--- a/lib/remote_files/fog_store.rb
+++ b/lib/remote_files/fog_store.rb
@@ -35,7 +35,7 @@ module RemoteFiles
     def url(identifier)
       case options[:provider]
       when 'AWS'
-        "https://s3.amazonaws.com/#{directory_name}/#{Fog::AWS.escape(identifier)}"
+        "https://#{aws_host}/#{directory_name}/#{Fog::AWS.escape(identifier)}"
       when 'Rackspace'
         "https://storage.cloudfiles.com/#{directory_name}/#{Fog::Rackspace.escape(identifier, '/')}"
       else
@@ -76,6 +76,15 @@ module RemoteFiles
     end
 
     protected
+
+    def aws_host
+      case options[:region]
+      when nil, 'us-east-1'
+        's3.amazonaws.com'
+      else
+        "s3-#{options[:region]}.amazonaws.com"
+      end
+    end
 
     def lookup_directory
       connection.directories.get(directory_name)

--- a/test/fog_store_test.rb
+++ b/test/fog_store_test.rb
@@ -95,6 +95,14 @@ describe RemoteFiles::FogStore do
       it 'should return an S3 url' do
         @store.url('identifier').must_equal('https://s3.amazonaws.com/directory/identifier')
       end
+
+      describe 'in a different region' do
+        before { @store.options[:region] = 'us-west-1' }
+
+        it 'should return an S3 url' do
+          @store.url('identifier').must_equal('https://s3-us-west-1.amazonaws.com/directory/identifier')
+        end
+      end
     end
 
     describe 'for CloudFiles connections' do


### PR DESCRIPTION
@staugaard

Unfortunately, it doesn't seem possible to grab the "@host" variable from #connection without resorting to instance_variable_get. So, I guess we can copy the logic since it seems to be pretty stable.
