### PR TITLE
add S3 server side encryption to remote files

### DIFF
--- a/lib/remote_files/fog_store.rb
+++ b/lib/remote_files/fog_store.rb
@@ -7,7 +7,8 @@ module RemoteFiles
         :body         => file.content,
         :content_type => file.content_type,
         :key          => file.identifier,
-        :public       => options[:public]
+        :public       => options[:public],
+        :encryption   => 'AES256'
       )
 
       raise RemoteFiles::Error unless success


### PR DESCRIPTION
@tsturge @staugaard 

This enables server side encryption as a default for remote files.
