### PR TITLE
support for server-side encryption

### DIFF
--- a/lib/remote_files/fog_store.rb
+++ b/lib/remote_files/fog_store.rb
@@ -7,7 +7,8 @@ module RemoteFiles
         :body         => file.content,
         :content_type => file.content_type,
         :key          => file.identifier,
-        :public       => options[:public]
+        :public       => options[:public],
+        :encryption   => options[:encryption]
       )
 
       raise RemoteFiles::Error unless success


### PR DESCRIPTION
@marcosvm

This is an alternative to #10 

The only difference is that encryption now is configurable.

Unfortunately this is not testable as the fog mock store does not store the encryption attribute.
