### PR TITLE
Require an identifier when deleting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,11 @@ rvm:
   - 2.0
   - 2.1
   - 2.2
-  - jruby-9.0.0.0
+  - 2.3
+  - 2.4
+  - 2.5
+  - 2.6
+  - jruby
 sudo: false
 cache: bundler
 branches:

--- a/lib/remote_files/fog_store.rb
+++ b/lib/remote_files/fog_store.rb
@@ -48,6 +48,11 @@ module RemoteFiles
     end
 
     def delete!(identifier)
+      if identifier.to_s.chomp.empty?
+        message = "Empty identifier is not supported"
+        raise RemoteFiles::Error, message
+      end
+
       connection.delete_object(directory.key, identifier)
     rescue Fog::Errors::NotFound, Excon::Errors::NotFound
       raise NotFoundError, $!.message, $!.backtrace

--- a/test/fog_store_test.rb
+++ b/test/fog_store_test.rb
@@ -199,6 +199,14 @@ describe RemoteFiles::FogStore do
       lambda { @store.delete!('unknown') }.must_raise(RemoteFiles::NotFoundError)
     end
 
+    it 'raises a RemoteFiles::Error if trying to delete with no identifier' do
+      @store.directory.key = 'directory'
+      ex = assert_raises RemoteFiles::Error do
+        @store.delete!("")
+      end
+      ex.message.must_equal "Empty identifier is not supported"
+    end
+
     it 'should destroy the file' do
       assert @store.directory.files.get('identifier')
 


### PR DESCRIPTION
When deleting from a remote store, having no identifier would try to
delete the directory. This is probably unintended behaviour, and should
be prevented.