### PR TITLE
Lower default request retries to 0

### DIFF
--- a/lib/remote_files/fog_store.rb
+++ b/lib/remote_files/fog_store.rb
@@ -59,10 +59,11 @@ module RemoteFiles
     end
 
     def connection
-      connection_options = options.dup
-      connection_options.delete(:directory)
-      connection_options.delete(:public)
-      @connection ||= Fog::Storage.new(connection_options)
+      opts = options.dup
+      opts.delete(:directory)
+      opts.delete(:public)
+      opts[:connection_options] ||= default_connection_options
+      @connection ||= Fog::Storage.new(opts)
     end
 
     def directory_name
@@ -74,6 +75,13 @@ module RemoteFiles
     end
 
     protected
+
+    def default_connection_options
+      {
+        retry_limit: 0,
+        retry_interval: 0
+      }
+    end
 
     def aws_host
       case options[:region]


### PR DESCRIPTION
Part 3 of splitting #21 

By default, excon, the gem used by fog to make the requests comes with 4
default retries: https://github.com/excon/excon/blob/611c88f63bfc2b963b4771313082ba51c99e6cf3/lib/excon/connection.rb#L60-L61

These retries are doing more harm than help, puting gasonline on fire,
everytime there's an issue, blocking the execution for longer.

Here, we're setting the default to 0, and allowing clients to set their own number of
retries and the retry_interval.