### PR TITLE
Fix gemspec license

### DIFF
--- a/remote_files.gemspec
+++ b/remote_files.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new 'remote_files', RemoteFiles::VERSION do |gem|
   gem.description   = 'A library for uploading files to multiple remote storage backends like Amazon S3 and Rackspace CloudFiles.'
   gem.summary       = 'The purpose of the library is to implement a simple interface for uploading files to multiple backends and to keep the backends in sync, so that your app will keep working when one backend is down.'
   gem.homepage      = 'https://github.com/zendesk/remote_files'
-  gem.license       = 'Apache License Version 2.0'
+  gem.license       = 'Apache-2.0'
 
   gem.files         = `git ls-files lib README.md`.split("\n")
 


### PR DESCRIPTION
Gets rid of a warning when building the gem:

```sh
➜  remote_files git:(master) gem build remote_files.gemspec
WARNING:  license value 'Apache License Version 2.0' is invalid.  Use a license identifier from
http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
Did you mean 'Apache-2.0'?
```