### PR TITLE
[EM-7092] Updated file retrieve to populate stored_in field

### DIFF
--- a/lib/remote_files/file.rb
+++ b/lib/remote_files/file.rb
@@ -3,7 +3,7 @@ module RemoteFiles
     attr_reader :content, :content_type, :identifier, :stored_in, :configuration
 
     def initialize(identifier, options = {})
-      known_keys = [:identifier, :stored_in, :content_type, :configuration, :content]
+      known_keys = [:identifier, :stored_in, :content_type, :configuration, :content, :populate_stored_in]
       known_keys.each do |key|
         options[key] ||= options.delete(key.to_s)
       end
@@ -79,9 +79,8 @@ module RemoteFiles
           next unless file
           @content      = file.content
           @content_type = file.content_type
-          if @options[:populate_stored_in]
-            @stored_in = file.stored_in
-          end
+          # :populate_stored_in is a boolean
+          @stored_in = file.stored_in if options.key?(:populate_stored_in) && (@options[:populate_stored_in])
           return true
         rescue Error => e
         end

--- a/lib/remote_files/file.rb
+++ b/lib/remote_files/file.rb
@@ -82,7 +82,7 @@ module RemoteFiles
           @content      = file.content
           @content_type = file.content_type
           # :populate_stored_in is a boolean
-          @stored_in = file.stored_in if options.key?(:populate_stored_in) && (@options[:populate_stored_in])
+          @stored_in = file.stored_in if @populate_stored_in
           return true
         rescue Error => e
         end

--- a/lib/remote_files/file.rb
+++ b/lib/remote_files/file.rb
@@ -79,6 +79,9 @@ module RemoteFiles
           next unless file
           @content      = file.content
           @content_type = file.content_type
+          if @options[:populate_stored_in]
+            @stored_in = file.stored_in
+          end
           return true
         rescue Error => e
         end

--- a/lib/remote_files/file.rb
+++ b/lib/remote_files/file.rb
@@ -1,6 +1,6 @@
 module RemoteFiles
   class File
-    attr_reader :content, :content_type, :identifier, :stored_in, :configuration
+    attr_reader :content, :content_type, :identifier, :stored_in, :configuration, :populate_stored_in
 
     def initialize(identifier, options = {})
       known_keys = [:identifier, :stored_in, :content_type, :configuration, :content, :populate_stored_in]
@@ -14,6 +14,7 @@ module RemoteFiles
       @content_type  = options[:content_type]
       @configuration = RemoteFiles::CONFIGURATIONS[(options[:configuration] || :default).to_sym]
       @logger        = options[:logger]
+      @populate_stored_in = options[:populate_stored_in]
       @options       = options
     end
 
@@ -34,7 +35,8 @@ module RemoteFiles
         :identifier    => identifier,
         :stored_in     => stored_in,
         :content_type  => content_type,
-        :configuration => configuration.name
+        :configuration => configuration.name,
+        :populate_stored_in => populate_stored_in
       )
     end
 

--- a/test/file_test.rb
+++ b/test/file_test.rb
@@ -135,7 +135,7 @@ describe RemoteFiles::File do
 
   describe '#retrieve!' do
     before do
-      @file_with_content = RemoteFiles::File.new('identifier', :content => 'content', :content_type => 'content_type', :populate_stored_in => true)
+      @file_with_content = RemoteFiles::File.new('identifier', :content => 'content', :content_type => 'content_type', :populate_stored_in => nil)
 
       @store = stub
       @file.stubs(:stores).returns([@store])
@@ -147,16 +147,14 @@ describe RemoteFiles::File do
         @store.expects(:retrieve!).returns(@file_with_content)
       end
 
-      it 'fills in the content, content_type, and stored_in' do
+      it 'fills in the content and content_type' do
         @file.content.must_be_nil
         @file.content_type.must_be_nil
-        @file.populate_stored_in.must_be_nil
 
         @file.retrieve!
 
         @file.content.must_equal 'content'
         @file.content_type.must_equal 'content_type'
-        @file.stored_in.must_equal [@store]
       end
     end
 
@@ -167,6 +165,40 @@ describe RemoteFiles::File do
 
       it 'raises a NotFoundError' do
         proc { @file.retrieve! }.must_raise(RemoteFiles::NotFoundError)
+      end
+    end
+
+    describe 'populate_stored_in is set' do
+      before do
+        @file_with_content = RemoteFiles::File.new('identifier', :content => 'content', :content_type => 'content_type', :populate_stored_in => true)
+      end
+
+      describe 'when the file is found' do
+        before do
+          @store.expects(:retrieve!).returns(@file_with_content)
+        end
+
+        it 'fills in the content, content_type, and stored_in' do
+          @file.content.must_be_nil
+          @file.content_type.must_be_nil
+          @file.populate_stored_in.must_be_nil
+
+          @file.retrieve!
+
+          @file.content.must_equal 'content'
+          @file.content_type.must_equal 'content_type'
+          @file.stored_in.must_equal [@store]
+        end
+      end
+
+      describe 'when the file is not found' do
+        before do
+          @store.expects(:retrieve!).returns(nil)
+        end
+
+        it 'raises a NotFoundError' do
+          proc { @file.retrieve! }.must_raise(RemoteFiles::NotFoundError)
+        end
       end
     end
   end

--- a/test/file_test.rb
+++ b/test/file_test.rb
@@ -135,10 +135,11 @@ describe RemoteFiles::File do
 
   describe '#retrieve!' do
     before do
-      @file_with_content = RemoteFiles::File.new('identifier', :content => 'content', :content_type => 'content_type')
+      @file_with_content = RemoteFiles::File.new('identifier', :content => 'content', :content_type => 'content_type', :populate_stored_in => true)
 
       @store = stub
       @file.stubs(:stores).returns([@store])
+      @file.stubs(:stored_in).returns([@store])
     end
 
     describe 'when the file is found' do
@@ -146,14 +147,16 @@ describe RemoteFiles::File do
         @store.expects(:retrieve!).returns(@file_with_content)
       end
 
-      it 'fills in the content and content_type' do
+      it 'fills in the content, content_type, and stored_in' do
         @file.content.must_be_nil
         @file.content_type.must_be_nil
+        @file.populate_stored_in.must_be_nil
 
         @file.retrieve!
 
         @file.content.must_equal 'content'
         @file.content_type.must_equal 'content_type'
+        @file.stored_in.must_equal [@store]
       end
     end
 

--- a/test/file_test.rb
+++ b/test/file_test.rb
@@ -156,7 +156,7 @@ describe RemoteFiles::File do
         @file.content_type.must_equal 'content_type'
       end
 
-      it 'verifies stored_in does not get populated' do
+      it 'does not fill in stored_in' do
         @file.stored_in.must_equal []
 
         @file.retrieve!

--- a/test/file_test.rb
+++ b/test/file_test.rb
@@ -139,7 +139,6 @@ describe RemoteFiles::File do
 
       @store = stub
       @file.stubs(:stores).returns([@store])
-      @file.stubs(:stored_in).returns([@store])
     end
 
     describe 'when the file is found' do
@@ -156,6 +155,14 @@ describe RemoteFiles::File do
         @file.content.must_equal 'content'
         @file.content_type.must_equal 'content_type'
       end
+
+      it 'verifies stored_in does not get populated' do
+        @file.stored_in.must_equal []
+
+        @file.retrieve!
+
+        @file.stored_in.must_equal []
+      end
     end
 
     describe 'when the file is not found' do
@@ -171,6 +178,7 @@ describe RemoteFiles::File do
     describe 'populate_stored_in is set' do
       before do
         @file_with_content = RemoteFiles::File.new('identifier', :content => 'content', :content_type => 'content_type', :populate_stored_in => true)
+        @file.stubs(:stored_in).returns([@store])
       end
 
       describe 'when the file is found' do

--- a/test/resque_job_test.rb
+++ b/test/resque_job_test.rb
@@ -28,6 +28,20 @@ describe RemoteFiles::ResqueJob do
       RemoteFiles.synchronize_stores(@file)
     end
 
+    it 'should still setup the right synchronize_stores hook even with populate_stored_in set' do
+      Resque.expects(:enqueue).with(RemoteFiles::ResqueJob,
+        :identifier    => 'identifier',
+        :content_type  => 'text/plain',
+        :stored_in     => [:s3],
+        :foo           => :bar,
+        :configuration => :default,
+        :populate_stored_in => true,
+        :_action       => :synchronize
+      )
+
+      RemoteFiles.synchronize_stores(@file)
+    end
+
     it 'should setup the right delete_file hook' do
       Resque.expects(:enqueue).with(RemoteFiles::ResqueJob,
         :identifier    => 'identifier',
@@ -36,6 +50,20 @@ describe RemoteFiles::ResqueJob do
         :foo           => :bar,
         :configuration => :default,
         :populate_stored_in => nil,
+        :_action       => :delete
+      )
+
+      RemoteFiles.delete_file(@file)
+    end
+
+    it 'should still setup the right delete_file hook even with populate_stored_in set' do
+      Resque.expects(:enqueue).with(RemoteFiles::ResqueJob,
+        :identifier    => 'identifier',
+        :content_type  => 'text/plain',
+        :stored_in     => [:s3],
+        :foo           => :bar,
+        :configuration => :default,
+        :populate_stored_in => true,
         :_action       => :delete
       )
 

--- a/test/resque_job_test.rb
+++ b/test/resque_job_test.rb
@@ -28,20 +28,6 @@ describe RemoteFiles::ResqueJob do
       RemoteFiles.synchronize_stores(@file)
     end
 
-    it 'should still setup the right synchronize_stores hook even with populate_stored_in set' do
-      Resque.expects(:enqueue).with(RemoteFiles::ResqueJob,
-        :identifier    => 'identifier',
-        :content_type  => 'text/plain',
-        :stored_in     => [:s3],
-        :foo           => :bar,
-        :configuration => :default,
-        :populate_stored_in => true,
-        :_action       => :synchronize
-      )
-
-      RemoteFiles.synchronize_stores(@file)
-    end
-
     it 'should setup the right delete_file hook' do
       Resque.expects(:enqueue).with(RemoteFiles::ResqueJob,
         :identifier    => 'identifier',
@@ -56,19 +42,6 @@ describe RemoteFiles::ResqueJob do
       RemoteFiles.delete_file(@file)
     end
 
-    it 'should still setup the right delete_file hook even with populate_stored_in set' do
-      Resque.expects(:enqueue).with(RemoteFiles::ResqueJob,
-        :identifier    => 'identifier',
-        :content_type  => 'text/plain',
-        :stored_in     => [:s3],
-        :foo           => :bar,
-        :configuration => :default,
-        :populate_stored_in => true,
-        :_action       => :delete
-      )
-
-      RemoteFiles.delete_file(@file)
-    end
   end
 
   describe "running the job" do
@@ -102,4 +75,78 @@ describe RemoteFiles::ResqueJob do
     end
   end
 
+  describe 'loading the implementation file with populate_stored_in set' do
+    before do
+      @file = RemoteFiles::File.new('identifier',
+        :content_type => 'text/plain',
+        :content      => 'content',
+        :stored_in    => [:s3],
+        :foo          => :bar,
+        :populate_stored_in => true
+      )
+
+      load 'remote_files/resque_job.rb'
+    end
+
+    it 'should setup the right synchronize_stores hook' do
+      Resque.expects(:enqueue).with(RemoteFiles::ResqueJob,
+        :identifier    => 'identifier',
+        :content_type  => 'text/plain',
+        :stored_in     => [:s3],
+        :foo           => :bar,
+        :configuration => :default,
+        :populate_stored_in => true,
+        :_action       => :synchronize
+      )
+
+      RemoteFiles.synchronize_stores(@file)
+    end
+
+    it 'should setup the right delete_file hook' do
+      Resque.expects(:enqueue).with(RemoteFiles::ResqueJob,
+        :identifier    => 'identifier',
+        :content_type  => 'text/plain',
+        :stored_in     => [:s3],
+        :foo           => :bar,
+        :configuration => :default,
+        :populate_stored_in => true,
+        :_action       => :delete
+      )
+
+      RemoteFiles.delete_file(@file)
+    end
+  end
+
+  describe "running the job with populate_stored_in set" do
+    before do
+      @options = {
+        :identifier   => 'identifier',
+        :content_type => 'text/plain',
+        :stored_in    => [:s3],
+        :populate_stored_in => true,
+        :foo          => :bar
+      }
+
+      @file = stub
+
+      RemoteFiles::File.expects(:new).with('identifier',
+        :content_type => 'text/plain',
+        :stored_in    => [:s3],
+        :populate_stored_in => true,
+        :foo          => :bar
+      ).returns(@file)
+    end
+
+    it 'should call #synchronize! on the reconstructed file when asked to' do
+      @file.expects(:synchronize!)
+
+      RemoteFiles::ResqueJob.perform(@options.merge(:_action => :synchronize))
+    end
+
+    it 'should call #delete_now! on the reconstructed file when asked to' do
+      @file.expects(:delete_now!)
+
+      RemoteFiles::ResqueJob.perform(@options.merge(:_action => :delete))
+    end
+  end
 end

--- a/test/resque_job_test.rb
+++ b/test/resque_job_test.rb
@@ -21,6 +21,7 @@ describe RemoteFiles::ResqueJob do
         :stored_in     => [:s3],
         :foo           => :bar,
         :configuration => :default,
+        :populate_stored_in => nil,
         :_action       => :synchronize
       )
 
@@ -34,6 +35,7 @@ describe RemoteFiles::ResqueJob do
         :stored_in     => [:s3],
         :foo           => :bar,
         :configuration => :default,
+        :populate_stored_in => nil,
         :_action       => :delete
       )
 


### PR DESCRIPTION
### Description
In order to fix the redaction bug on classic, the file retrieval needs to also grab the stored_in value when RemoteFiles does it retrieval.

### References
* Jira: https://zendesk.atlassian.net/browse/EM-7092

### Risks
* Low: change is gated behind an option that acts as an arturo.