### PR TITLE
[EM-6932] Add DataDog metrics and monitors on excon SSL errors in MPQ

### DIFF
--- a/lib/remote_files/configuration.rb
+++ b/lib/remote_files/configuration.rb
@@ -100,6 +100,7 @@ module RemoteFiles
         begin
           stored = store.store!(file)
           file.stored_in << store.identifier
+          raise ::RemoteFiles::Error.new('testing remote files error')
           break
         rescue ::RemoteFiles::Error => e
           file.logger.info(e) if file.logger

--- a/lib/remote_files/configuration.rb
+++ b/lib/remote_files/configuration.rb
@@ -100,7 +100,6 @@ module RemoteFiles
         begin
           stored = store.store!(file)
           file.stored_in << store.identifier
-          raise ::RemoteFiles::Error.new('testing remote files error')
           break
         rescue ::RemoteFiles::Error => e
           file.logger.info(e) if file.logger

--- a/lib/remote_files/configuration.rb
+++ b/lib/remote_files/configuration.rb
@@ -103,6 +103,7 @@ module RemoteFiles
           break
         rescue ::RemoteFiles::Error => e
           file.logger.info(e) if file.logger
+          file.errors.push(e) if file.errors
           exception = e
         end
       end

--- a/lib/remote_files/file.rb
+++ b/lib/remote_files/file.rb
@@ -3,7 +3,7 @@ module RemoteFiles
     attr_reader :content, :content_type, :identifier, :stored_in, :configuration, :populate_stored_in, :last_update_ts
 
     def initialize(identifier, options = {})
-      known_keys = [:identifier, :stored_in, :content_type, :configuration, :content, :populate_stored_in, :last_update_ts]
+      known_keys = [:identifier, :stored_in, :content_type, :configuration, :content, :populate_stored_in, :last_update_ts, :errors]
       known_keys.each do |key|
         options[key] ||= options.delete(key.to_s)
       end
@@ -16,6 +16,7 @@ module RemoteFiles
       @configuration = RemoteFiles::CONFIGURATIONS[(options[:configuration] || :default).to_sym]
       @logger        = options[:logger]
       @populate_stored_in = options[:populate_stored_in]
+      @errors        = options[:errors]
       @options       = options
     end
 
@@ -86,6 +87,7 @@ module RemoteFiles
           @stored_in = file.stored_in if @populate_stored_in
           return true
         rescue Error => e
+          @errors.push(e)
         end
       end
 

--- a/lib/remote_files/file.rb
+++ b/lib/remote_files/file.rb
@@ -87,7 +87,6 @@ module RemoteFiles
           @stored_in = file.stored_in if @populate_stored_in
           return true
         rescue Error => e
-          @errors.push(e)
         end
       end
 

--- a/lib/remote_files/file.rb
+++ b/lib/remote_files/file.rb
@@ -16,7 +16,7 @@ module RemoteFiles
       @configuration = RemoteFiles::CONFIGURATIONS[(options[:configuration] || :default).to_sym]
       @logger        = options[:logger]
       @populate_stored_in = options[:populate_stored_in]
-      @errors        = options[:errors]
+      @errors        = options[:errors] || []
       @options       = options
     end
 

--- a/lib/remote_files/file.rb
+++ b/lib/remote_files/file.rb
@@ -1,6 +1,6 @@
 module RemoteFiles
   class File
-    attr_reader :content, :content_type, :identifier, :stored_in, :configuration, :populate_stored_in, :last_update_ts
+    attr_reader :content, :content_type, :identifier, :stored_in, :configuration, :populate_stored_in, :last_update_ts, :errors
 
     def initialize(identifier, options = {})
       known_keys = [:identifier, :stored_in, :content_type, :configuration, :content, :populate_stored_in, :last_update_ts, :errors]

--- a/lib/remote_files/file.rb
+++ b/lib/remote_files/file.rb
@@ -16,7 +16,7 @@ module RemoteFiles
       @configuration = RemoteFiles::CONFIGURATIONS[(options[:configuration] || :default).to_sym]
       @logger        = options[:logger]
       @populate_stored_in = options[:populate_stored_in]
-      @errors        = options[:errors] || []
+      @errors        = options[:errors]
       @options       = options
     end
 

--- a/lib/remote_files/version.rb
+++ b/lib/remote_files/version.rb
@@ -1,3 +1,3 @@
 module RemoteFiles
-  VERSION = '3.4.0'
+  VERSION = '3.4.0-alpha'
 end

--- a/lib/remote_files/version.rb
+++ b/lib/remote_files/version.rb
@@ -1,3 +1,3 @@
 module RemoteFiles
-  VERSION = '3.4.0-alpha'
+  VERSION = '3.4.0-beta'
 end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -118,7 +118,7 @@ describe RemoteFiles::Configuration do
         @mock_store2.data['file'].must_be_nil
       end
 
-      it 'should not adds the errors into the file' do
+      it 'should not add any errors into the file' do
         @file.errors.length.must_equal 0
       end
     end
@@ -143,9 +143,7 @@ describe RemoteFiles::Configuration do
       end
 
       it 'adds the errors into the file'  do
-        io = StringIO.new
-        io.puts @file.errors[0]
-        io.string.must_match /RemoteFiles::Error/
+        @file.errors[0].to_s.must_match /RemoteFiles::Error/
       end
     end
 
@@ -157,9 +155,7 @@ describe RemoteFiles::Configuration do
       end
 
       it 'adds the errors into the file' do
-        io = StringIO.new
-        io.puts @file2.errors[0]
-        io.string.must_match /RemoteFiles::Error/
+        @file2.errors[0].to_s.must_match /RemoteFiles::Error/
       end
     end
 

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -139,11 +139,11 @@ describe RemoteFiles::Configuration do
       end
 
       it 'logs that the first store failed' do
-        @log.string.must_match /RemoteFiles::Error/
+        @log.string.must_match(/RemoteFiles::Error/)
       end
 
       it 'adds the errors into the file'  do
-        @file.errors[0].to_s.must_match /RemoteFiles::Error/
+        @file.errors[0].to_s.must_match(/RemoteFiles::Error/)
       end
     end
 

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -117,6 +117,10 @@ describe RemoteFiles::Configuration do
         @mock_store1.data['file'].must_equal(:content => 'content', :content_type => 'text/plain', :last_update_ts => @file.last_update_ts)
         @mock_store2.data['file'].must_be_nil
       end
+
+      it 'should not adds the errors into the file' do
+        @file.errors.length.must_equal 0
+      end
     end
 
     describe 'when the first store fails' do
@@ -141,6 +145,20 @@ describe RemoteFiles::Configuration do
       it 'adds the errors into the file'  do
         io = StringIO.new
         io.puts @file.errors[0]
+        io.string.must_match /RemoteFiles::Error/
+      end
+    end
+
+    describe 'when configured without an errors array' do
+      before do
+        @file2 = RemoteFiles::File.new('file', :configuration => :test, :content => 'content', :content_type => 'text/plain', :last_update_ts => Time.utc(1970, 4, 22))
+        @mock_store1.expects(:store!).with(@file2).raises(RemoteFiles::Error)
+        @configuration.store_once!(@file2)
+      end
+
+      it 'adds the errors into the file' do
+        io = StringIO.new
+        io.puts @file2.errors[0]
         io.string.must_match /RemoteFiles::Error/
       end
     end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -154,8 +154,8 @@ describe RemoteFiles::Configuration do
         @configuration.store_once!(@file2)
       end
 
-      it 'adds the errors into the file' do
-        @file2.errors[0].to_s.must_match /RemoteFiles::Error/
+      it 'errors array returns nil' do
+        assert_nil @file2.errors
       end
     end
 

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -5,7 +5,7 @@ require 'remote_files/mock_store'
 describe RemoteFiles::Configuration do
   before do
     @configuration = RemoteFiles.configure(:test)
-    @file = RemoteFiles::File.new('file', :configuration => :test, :content => 'content', :content_type => 'text/plain', :last_update_ts => Time.utc(1970, 4, 22))
+    @file = RemoteFiles::File.new('file', :configuration => :test, :content => 'content', :content_type => 'text/plain', :last_update_ts => Time.utc(1970, 4, 22), :errors => [])
     @mock_store1 = @configuration.add_store(:mock1, :class => RemoteFiles::MockStore)
     @mock_store2 = @configuration.add_store(:mock2, :class => RemoteFiles::MockStore, :read_only => false)
   end
@@ -136,6 +136,12 @@ describe RemoteFiles::Configuration do
 
       it 'logs that the first store failed' do
         @log.string.must_match /RemoteFiles::Error/
+      end
+
+      it 'adds the errors into the file'  do
+        io = StringIO.new
+        io.puts @file.errors[0]
+        io.string.must_match /RemoteFiles::Error/
       end
     end
 

--- a/test/resque_job_test.rb
+++ b/test/resque_job_test.rb
@@ -23,7 +23,8 @@ describe RemoteFiles::ResqueJob do
         :configuration => :default,
         :populate_stored_in => nil,
         :_action       => :synchronize,
-        :last_update_ts => nil
+        :last_update_ts => nil,
+        :errors => nil
       )
 
       RemoteFiles.synchronize_stores(@file)
@@ -38,7 +39,8 @@ describe RemoteFiles::ResqueJob do
         :configuration => :default,
         :populate_stored_in => nil,
         :_action       => :delete,
-        :last_update_ts => nil
+        :last_update_ts => nil,
+        :errors => nil
       )
 
       RemoteFiles.delete_file(@file)
@@ -99,7 +101,8 @@ describe RemoteFiles::ResqueJob do
         :configuration => :default,
         :populate_stored_in => true,
         :_action       => :synchronize,
-        :last_update_ts => nil
+        :last_update_ts => nil,
+        :errors => nil
       )
 
       RemoteFiles.synchronize_stores(@file)
@@ -114,7 +117,8 @@ describe RemoteFiles::ResqueJob do
         :configuration => :default,
         :populate_stored_in => true,
         :_action       => :delete,
-        :last_update_ts => nil
+        :last_update_ts => nil,
+        :errors => nil
       )
 
       RemoteFiles.delete_file(@file)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,8 +2,8 @@ require 'bundler/setup'
 
 require 'minitest/autorun'
 require 'minitest/rg'
-require 'mocha/setup'
 require 'fog/aws'
+require 'mocha/minitest'
 
 
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)


### PR DESCRIPTION
The plan is to have an errors array and push into that every time there is a `RemoteFiles::Error`.  In MPQ we will check that array and add a monitor to check if there is an error in that array. 

Connects to MPQ here: https://github.com/zendesk/zendesk_mail_parsing_queue/pull/1293
JIRA: https://zendesk.atlassian.net/browse/EM-6932

### Testing
This was tested in MPQ with a branch of remote_files that raises `::RemoteFiles::Error` with the metric working successfully. 
<img width="1587" alt="Screen Shot 2022-11-10 at 3 10 40 PM" src="https://user-images.githubusercontent.com/32755742/201225266-3ffacb34-6c67-4d94-9847-887f0970bb6a.png">

On Classic I tested it through making sure that the unit tests were working correctly and then deploying to staging and testing it with the `redact_json_files!` function that uses the remote_files gem methods affected (store_once!). Also tested rejecting emails since we use delete remote_files when that happens to confirm that it is still running correctly with the gem bump