### PR TITLE
add tests on ruby 3.2 and 3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.1', '2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', 'jruby' ]
+        ruby: [ '2.1', '2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', 'jruby' ]
         task: [ 'bundle exec rake' ]
     name: Ruby ${{ matrix.ruby }} - ${{ matrix.task }}
     steps:
-    - uses: zendesk/checkout@v2
-    - uses: zendesk/setup-ruby@v1
+    - uses: actions/checkout@v4
+    - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        ruby: [ '2.1', '2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', 'jruby' ]
+        ruby: [ '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', 'jruby' ]
         task: [ 'bundle exec rake' ]
     name: Ruby ${{ matrix.ruby }} - ${{ matrix.task }}
     steps:

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,7 +10,7 @@ $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require 'remote_files'
 Fog.mock!
 
-MiniTest::Spec.class_eval do
+Minitest::Spec.class_eval do
   before do
     Fog::Mock.reset
 


### PR DESCRIPTION
Also, drops tests on Ruby 2.1 and 2.2 (which are not supported by Bundler 2.x).