### PR TITLE
Remove the specification of public in remote_files

### DIFF
--- a/lib/remote_files/fog_store.rb
+++ b/lib/remote_files/fog_store.rb
@@ -134,9 +134,9 @@ module RemoteFiles
           :body => file.content,
           :content_type => file.content_type,
           :key => file.identifier,
-          :public => options[:public],
           :encryption => options[:encryption]
         }
+      store_options[:public] = options[:public] if options.key?(:public)
       if file.options[:multipart_chunk_size]
         raise RemoteFiles::Error.new("Only S3 supports the multipart_chunk_size option") unless options[:provider] == 'AWS'
         chunk_size = file.options[:multipart_chunk_size]

--- a/lib/remote_files/version.rb
+++ b/lib/remote_files/version.rb
@@ -1,3 +1,3 @@
 module RemoteFiles
-  VERSION = '3.5.1'
+  VERSION = '3.6.0'
 end


### PR DESCRIPTION
### Context

In this PR, we're going to specify public key only when public key exists.
And release the new tag v3.6.0.

#### Tested
The pre-release version of this changes have been tested in Classic and MPQ.
* After this PR got merged, I'll bump remote_files v3.6.0 to Classic and MPQ on the following Monday (May 20th).

### References
- Jira: [EM-8946](https://zendesk.atlassian.net/browse/EM-8946)
- https://zendesk.slack.com/archives/G018CGN8VGD/p1715797137651939?thread_ts=1715715276.259219&cid=G018CGN8VGD
- https://zendesk.slack.com/archives/C0664N4QE2D/p1715794725371919?thread_ts=1715711144.584579&cid=C0664N4QE2D

[EM-8946]: https://zendesk.atlassian.net/browse/EM-8946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ