### PR TITLE
Re-raise non 404 errors during parallel deletion

### DIFF
--- a/lib/remote_files/configuration.rb
+++ b/lib/remote_files/configuration.rb
@@ -151,8 +151,9 @@ module RemoteFiles
       true
     end
 
-    # This method is used to delete a file from all stores in parallel
-    # exceptions are passed back to the caller
+    # Deletes a file from all writable stores in parallel.
+    # When the file is missing the Future's value is set to NotFoundError exception.
+    # Re-raises any other exceptions, but doesn't prevent concurrent requests from being executed.
     def delete_in_parallel!(file, stores, exceptions)
       pool = Concurrent::FixedThreadPool.new(@max_delete_in_parallel)
 
@@ -167,7 +168,7 @@ module RemoteFiles
       end
 
       futures.each do |future|
-        result = future.value
+        result = future.value!
         exceptions << result if result.is_a?(Exception)
       end
 

--- a/lib/remote_files/version.rb
+++ b/lib/remote_files/version.rb
@@ -1,3 +1,3 @@
 module RemoteFiles
-  VERSION = '3.7.0'
+  VERSION = '3.7.1'
 end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -270,6 +270,13 @@ describe RemoteFiles::Configuration do
       end
     end
 
+    describe 'when there is a non-404 error' do
+      it 're-raises the error' do
+        @mock_store1.expects(:delete!).raises(Excon::Errors::Error)
+        proc { @configuration.delete_now!(@file) }.must_raise(Excon::Errors::Error)
+      end
+    end
+
     describe 'when deleting files in parallel' do
       before do
         @read_only_store = @configuration.add_store(:read_only_store, :class => RemoteFiles::MockStore, :read_only => true)
@@ -300,6 +307,13 @@ describe RemoteFiles::Configuration do
         @read_only_store.expects(:delete!).never
 
         proc { @configuration.delete_now!(@file, parallel: true) }.must_raise(RemoteFiles::NotFoundError)
+      end
+
+      describe 'when there is a non-404 error' do
+        it 're-raises the error' do
+          @mock_store1.expects(:delete!).raises(Excon::Errors::Error)
+          proc { @configuration.delete_now!(@file, parallel: true) }.must_raise(Excon::Errors::Error)
+        end
       end
     end
   end


### PR DESCRIPTION
The intended behavior while handling errors for file deletion is to raise on general errors, and when the file can't be found in any of the writable stores.
The first implementation of parallel deletion was silently ignoring non-404 errors and was only raising for the 404 error mode.
This PR makes the parallel implementation re-raise any other unhandled errors, even though some concurrent requests are still being performed. This is now effectively the only difference in implementation. Serialized deletion stops execution as soon as it finds an Error. Parallel execution can't guarantee other requests haven't been performed by the time if finds an error in one of them.