### PR TITLE
Switch to trusted publishing workflow and run it on version.rb changes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,26 @@
-name: Publish Gem
+name: Publish to RubyGems.org
 
 on:
   push:
-    tags: v*
+    branches: main
+    paths: lib/remote_files/version.rb
+  workflow_dispatch:
 
 jobs:
-  call-workflow:
-    uses: zendesk/gw/.github/workflows/ruby-gem-publication.yml@main
-    secrets:
-      RUBY_GEMS_API_KEY: ${{ secrets.RUBY_GEMS_API_KEY }}
-      RUBY_GEMS_TOTP_DEVICE: ${{ secrets.RUBY_GEMS_TOTP_DEVICE }}
+  publish:
+    runs-on: ubuntu-latest
+    environment: rubygems-publish
+    if: github.repository_owner == 'zendesk'
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: false
+          ruby-version: "3.4"
+      - name: Install dependencies
+        run: bundle install
+      - uses: rubygems/release-gem@v1

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ file.store!
 This will store the file on one of the stores and then asynchronously copy the file to the remaining stores.
 `RemoteFiles::File#store!` will raise a `RemoteFiles::Error` if all storage backends are down.
 
-If you just need to store the file in a single store, the you can use `RemoteFiles::File#store_once!`. It will
+If you just need to store the file in a single store, then you can use `RemoteFiles::File#store_once!`. It will
 behave exactly like `RemoteFiles::File#store!`, but will not asynchronously copy the file to the other stores.
 
 ## Copyright and license
@@ -78,6 +78,20 @@ You may obtain a copy of the License at
 http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+### Releasing a new version
+A new version is published to RubyGems.org every time a change to `version.rb` is pushed to the `main` branch.
+In short, follow these steps:
+1. Update `version.rb`,
+2. merge this change into `main`, and
+3. look at [the action](https://github.com/zendesk/remote_files/actions/workflows/publish.yml) for output.
+
+To create a pre-release from a non-main branch:
+1. change the version in `version.rb` to something like `1.2.0.pre.1` or `2.0.0.beta.2`,
+2. push this change to your branch,
+3. go to [Actions → “Publish to RubyGems.org” on GitHub](https://github.com/zendesk/remote_files/actions/workflows/publish.yml),
+4. click the “Run workflow” button,
+5. pick your branch from a dropdown.
 
 ## Contributing
 


### PR DESCRIPTION
Switches to [a Trusted Publishing workflow](https://guides.rubygems.org/trusted-publishing/).
This workflow will run whenever `version.rb` is changed in the `main` branch.
Setting `ENV["gem_push"]` is also not necessary anymore.
This workflow relies on the main branch being named `main`. Please rename it (`main` is the standard name across Zendesk).
`bundler-cache` for `setup-ruby` is set to false to prevent [cache poisoning attacks](https://adnanthekhan.com/2024/05/06/the-monsters-in-your-build-cache-github-actions-cache-poisoning/).
Finally, we add a description of the new release process. Our README and CONTRIBUTING files don’t have a standard structure, so please check that we have updated a correct file and that the new section makes sense for this gem.
- [x] Release description has been updated correctly.
- [x] The main branch is renamed from `master` to `main`.